### PR TITLE
fix(pricing): center subtitle by fixing CSS specificity

### DIFF
--- a/app/v9/components/Pricing.tsx
+++ b/app/v9/components/Pricing.tsx
@@ -223,7 +223,7 @@ export function Pricing() {
           margin: 16px 0 16px 0;
         }
 
-        .v9-pricing-sub {
+        .v9-pricing-header .v9-pricing-sub {
           font-family: 'Inter', -apple-system, sans-serif;
           font-size: 1.05rem;
           color: rgba(12, 17, 23, 0.6);


### PR DESCRIPTION
## Summary
- `.v9 p { margin: 0 0 1em }` in page.css (specificity 0,1,1) was beating `.v9-pricing-sub { margin: 0 auto }` (specificity 0,1,0), setting left margin to 0
- Changed selector to `.v9-pricing-header .v9-pricing-sub` (specificity 0,2,0) to win and properly center the subtitle

## Test plan
- [ ] Visit /v9, scroll to Investment section
- [ ] Confirm subtitle "Both options get you to revenue faster..." is centered under heading