### PR TITLE
fix: scroll highlight visual bugs (Services + Pricing)

### DIFF
--- a/.flow/epics/fn-4-mgl.json
+++ b/.flow/epics/fn-4-mgl.json
@@ -1,0 +1,16 @@
+{
+  "branch_name": "fn-4-mgl",
+  "created_at": "2026-03-31T00:05:51.000746Z",
+  "default_impl": null,
+  "default_review": null,
+  "default_sync": null,
+  "depends_on_epics": [],
+  "id": "fn-4-mgl",
+  "next_task": 1,
+  "plan_review_status": "unknown",
+  "plan_reviewed_at": null,
+  "spec_path": ".flow/specs/fn-4-mgl.md",
+  "status": "open",
+  "title": "Fix scroll highlight visual bugs: Services + Pricing",
+  "updated_at": "2026-03-31T13:14:24.292897Z"
+}

--- a/.flow/specs/fn-4-mgl.md
+++ b/.flow/specs/fn-4-mgl.md
@@ -1,0 +1,83 @@
+# Fix scroll highlight visual bugs: Services + Pricing
+
+## Overview
+
+Two GSAP ScrollTrigger components — Services (4-column pin+scrub) and Pricing (per-row) — have visual bugs identified by code review and screenshot analysis, plus additional gaps found in plan review:
+
+**Services.tsx (fn-4-mgl.1):**
+1. Col 01: zero left padding → `inset box-shadow` flush at grid edge
+2. Col 03 at 1024px: also has zero left padding → same flush box-shadow in 2-col layout
+3. `animateBullets`: missing `gsap.killTweensOf` → overlapping tweens on fast scroll
+4. `animateBullets`: never called in `onEnter` → col 01 bullets static on initial enter
+5. Missing `onLeave` handler → last col stays highlighted after forward scroll exit
+6. Mobile path: `v9-services--highlight` class never removed on unmount
+7. Active column: `translateY(-2px)` bleeds into grid `border-top`
+8. Pin end `+=150%` too long
+9. `will-change` missing on animated elements
+10. `prefers-reduced-motion`: missing `transition: none` on both `.v9-lever-col` and `.v9-lever-title`
+
+**Pricing.tsx (fn-4-mgl.2):**
+1. Per-row `toggleClass` has no mutual exclusion → 2 rows active simultaneously
+2. Trigger range `top 60%/bottom 40%` creates dead zone → all rows at 0.65 opacity with none highlighted
+3. `translateY(-2px)` bleeds into row `border-bottom` above
+4. `v9-pricing--highlight` added via `once: true` but never removed by `ctx.revert()`
+5. `will-change: opacity, transform` planned but `transform` is being removed → use `will-change: opacity` only
+6. `prefers-reduced-motion`: missing `transition: none` on both `.v9-pricing-tier` and `.v9-pricing-name`
+
+## Scope
+
+- **Files**: `app/_home/components/Services.tsx`, `app/_home/components/Pricing.tsx`
+- **Not in scope**: ServicesCarousel, Hero, other components
+
+## Approach
+
+Two parallel tasks, fully independent (no shared files).
+
+**Task 1 — Services.tsx**: padding fix (base + 1024px breakpoint), animateBullets (killTweensOf + initial call), onLeave handler, mobile highlight cleanup, pin end 120%, remove translateY, will-change, reduced-motion (lever-col + lever-title).
+
+**Task 2 — Pricing.tsx**: mutual exclusion with single-point triggers (start: 'top 50%'), highlight cleanup (option A: classList.remove in cleanup), remove translateY, will-change: opacity only, reduced-motion (pricing-tier + pricing-name).
+
+## Quick commands
+
+```bash
+npm run dev
+# Visual checks:
+# 1. Services col 01 + col 03 (1024px): green bar inset, not flush
+# 2. Fast scrub: no bullet flicker
+# 3. Scroll past Services pin: no column stays highlighted
+# 4. Pricing: only 1 row active at a time, no dead zone
+# 5. Scroll above Pricing: highlight dimming clears
+# 6. Active cols/rows: no upward shift at border
+# 7. prefers-reduced-motion: instant highlight changes
+
+npx tsc --noEmit
+```
+
+## Acceptance
+
+- [ ] Services col 01 box-shadow visually inset at desktop
+- [ ] Services col 03 box-shadow visually inset at 1024px (2-col layout)
+- [ ] Col 01 bullets animate on initial enter (not static)
+- [ ] Fast scrub — no bullet flicker
+- [ ] Forward scroll past pin zone: no column stays highlighted
+- [ ] Mobile unmount: `v9-services--highlight` removed from DOM
+- [ ] Active column/row: no upward shift relative to borders
+- [ ] Services pin takes ~120% viewport height
+- [ ] Only one Pricing row active at a time
+- [ ] No dead zone between Pricing rows
+- [ ] Pricing highlight dimming clears when scrolling above section
+- [ ] TypeScript: no errors
+- [ ] Reduced-motion: all highlight transitions instant
+
+## Dependencies
+
+- fn-2-gfq.4 (Responsive layout: Pricing grid) also touches Pricing.tsx — coordinate to avoid conflicts
+
+## References
+
+- Services.tsx desktop pin: lines 127-151
+- Services.tsx mobile path: lines 104-114
+- Services.tsx animateBullets: lines 119-125
+- Services.tsx CSS active/reduced-motion: lines 406-432
+- Pricing.tsx per-row triggers: lines 130-137
+- Pricing.tsx CSS active/reduced-motion: lines 502-533

--- a/.flow/tasks/fn-4-mgl.1.json
+++ b/.flow/tasks/fn-4-mgl.1.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-03-31T00:06:40.388687Z",
+  "depends_on": [],
+  "epic": "fn-4-mgl",
+  "id": "fn-4-mgl.1",
+  "priority": null,
+  "spec_path": ".flow/tasks/fn-4-mgl.1.md",
+  "status": "todo",
+  "title": "Fix Services.tsx: padding, animateBullets, onLeave, pin end, will-change, reduced-motion",
+  "updated_at": "2026-03-31T12:40:23.318154Z"
+}

--- a/.flow/tasks/fn-4-mgl.1.md
+++ b/.flow/tasks/fn-4-mgl.1.md
@@ -1,0 +1,60 @@
+# fn-4-mgl.1 Fix Services.tsx: padding, animateBullets, onLeave, pin end, will-change, reduced-motion
+
+## Description
+Fix all visual/animation bugs in `app/_home/components/Services.tsx`.
+
+**Size:** M
+**Files:** `app/_home/components/Services.tsx` only
+**Blast zone:** Only `app/_home/page.tsx` imports this component. No shared CSS targets v9-lever-col outside the component's own `<style>` tag.
+
+### Approach
+
+1. **Padding fix**: Change `.v9-lever-col` base rule from `padding: 40px 28px 40px 0` to `padding: 40px 28px 40px 28px`. Remove the `:not(:first-child) { padding-left: 28px }` rule (lines 266-268) — it becomes redundant. Also update the 1024px breakpoint: change `padding-left: 0` to `padding-left: 28px` inside `.v9-lever-col:nth-child(3)` (line 368). The other rules in that block (border-right, padding-top, border-top) stay unchanged. Padding does not affect CSS grid column placement.
+
+2. **animateBullets — killTweensOf + initial call**: `animateBullets` is defined at lines 119-125 as a `const` inside the desktop `else` block, BEFORE `ScrollTrigger.create` at line 127 — it IS in scope for `onEnter`. Two changes needed:
+   - Add `gsap.killTweensOf(bullets)` immediately before `gsap.fromTo` inside `animateBullets`. Add `overwrite: 'auto'` to the tween config. This prevents stacked tweens on fast scrub.
+   - Call `animateBullets(cols[0])` at the END of the `onEnter` callback (after class toggles). Col 01 bullets are currently never animated on initial enter — only when `onUpdate` fires. Note: `animateBullets` targets `.v9-lever-bullets li` elements, NOT the cols themselves, so no conflict with the entrance stagger animation (which animates the col elements for opacity/y).
+
+3. **onLeave handler**: Desktop `ScrollTrigger.create` (line 127) has `onEnter` and `onLeaveBack` but no `onLeave`. Add `onLeave` that: removes `v9-services--highlight` from section, removes `v9-lever-col--active` from all cols, resets `prevActive = -1`. This is symmetric with `onLeaveBack` and cleans up forward-scroll exit.
+
+4. **Mobile highlight class leak**: Mobile path at line 106 calls `section.classList.add('v9-services--highlight')` with no removal path. `ctx.revert()` removes the per-col `toggleClass` classes but NOT manual `classList.add` calls. Fix: change `return () => ctx.revert()` at line 155 to `return () => { ctx.revert(); section.classList.remove('v9-services--highlight'); }`. `section` is guaranteed non-null at this point (guarded by line 71).
+
+5. **Pin end**: Change `end: '+=150%'` to `end: '+=120%'` at line 130.
+
+6. **Remove translateY from active state**: `.v9-services--highlight .v9-lever-col--active { transform: translateY(-2px) }` at line 419 causes the active column to shift into the grid's `border-top`. Remove `transform: translateY(-2px)` from the active rule. Also remove `transform 0.35s linear` from the `.v9-services--highlight .v9-lever-col` transition list (line 409) since transform no longer changes.
+
+7. **will-change**: Add `will-change: opacity, transform` to `.v9-lever-col` CSS rule (after the `border-right` line, before breakpoints). Omit `box-shadow` — expensive to composite.
+
+8. **Reduced-motion transition fix**: In `@media (prefers-reduced-motion: reduce)` block (lines 426-432), add `transition: none !important`. Also add `.v9-lever-col .v9-lever-title` to the selector list — it has `transition: color 0.35s linear` at lines 412-413 which is currently not covered.
+
+### Key context
+
+- `animateBullets` at line 119 is a `const` scoped to the desktop `else` block (line 115), defined before `ScrollTrigger.create` at line 127 — calling it from `onEnter` is valid without any hoisting.
+- `ctx.revert()` reverts GSAP ScrollTriggers and `toggleClass`-added classes but NOT manual `section.classList.add()` — `onLeave`/`onLeaveBack` handle desktop cleanup, explicit `classList.remove` in useEffect cleanup handles mobile and unmount.
+- Entrance stagger (lines 90-102) animates col elements (`opacity`, `y`). `animateBullets` animates bullet `li` elements (`opacity`, `x`). Different targets — no conflict.
+- `clearProps: 'opacity,transform'` at line 100 must not be removed.
+- CSS regression: all padding changes are non-conflicting. Mobile `padding: 32px 0 !important` (line 395) still overrides at ≤640px.
+- Refs: lines 90-102 (entrance), 104-155 (desktop pin + mobile), 254-268 (padding CSS), 356-404 (breakpoints), 406-432 (highlight + reduced-motion).
+
+## Acceptance
+
+- [ ] Col 01 green bar is visually inset at desktop (not flush with section left edge)
+- [ ] Col 03 green bar at 1024px (2-col layout) is also visually inset
+- [ ] All four columns have equal left padding (28px) at desktop
+- [ ] On initial scroll-enter, col 01 bullets animate in (not static)
+- [ ] Fast back/forth scrub — bullets do not flash or appear stuck at opacity 0
+- [ ] After scrolling forward past pin zone, no column stays highlighted (`onLeave` fires, classes removed)
+- [ ] After scrolling back above section, no column stays highlighted (`onLeaveBack` fires, classes removed)
+- [ ] On mobile: `v9-services--highlight` is removed from section element after component unmount
+- [ ] Active column does not shift upward — no border bleed
+- [ ] Pin zone scrolls through all 4 columns in ~120% viewport height
+- [ ] TypeScript: no errors (`npx tsc --noEmit`)
+- [ ] Reduced-motion: opacity and color changes are instant — no transition on `.v9-lever-col` or `.v9-lever-title`
+
+## Done summary
+TBD
+
+## Evidence
+- Commits:
+- Tests:
+- PRs:

--- a/.flow/tasks/fn-4-mgl.1.md
+++ b/.flow/tasks/fn-4-mgl.1.md
@@ -52,9 +52,8 @@ Fix all visual/animation bugs in `app/_home/components/Services.tsx`.
 - [ ] Reduced-motion: opacity and color changes are instant — no transition on `.v9-lever-col` or `.v9-lever-title`
 
 ## Done summary
-TBD
-
+Fixed all visual/animation bugs in Services.tsx: equal 28px padding on all cols (base + 1024px breakpoint), animateBullets with killTweensOf and initial col-01 call, onLeave handler symmetric with onLeaveBack, mobile highlight class cleanup, pin end reduced to 120%, removed translateY(-2px) from active state, added will-change, and transition:none for reduced-motion.
 ## Evidence
-- Commits:
-- Tests:
+- Commits: 3eb7ea2d190c2398e0a49bf96d0aaf11da3c64d0
+- Tests: npx tsc --noEmit, npm run build
 - PRs:

--- a/.flow/tasks/fn-4-mgl.2.json
+++ b/.flow/tasks/fn-4-mgl.2.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-03-31T00:06:40.589875Z",
+  "depends_on": [],
+  "epic": "fn-4-mgl",
+  "id": "fn-4-mgl.2",
+  "priority": null,
+  "spec_path": ".flow/tasks/fn-4-mgl.2.md",
+  "status": "todo",
+  "title": "Fix Pricing.tsx: mutual exclusion, translateY, cleanup, will-change, reduced-motion",
+  "updated_at": "2026-03-31T12:40:43.228010Z"
+}

--- a/.flow/tasks/fn-4-mgl.2.md
+++ b/.flow/tasks/fn-4-mgl.2.md
@@ -48,9 +48,8 @@ Fix all visual/animation bugs in `app/_home/components/Pricing.tsx`.
 - [ ] Reduced-motion: all highlight transitions are instant — no smooth fade on opacity or color for `.v9-pricing-tier` or `.v9-pricing-name`
 
 ## Done summary
-TBD
-
+Fixed all visual/animation bugs in Pricing.tsx: replaced per-row toggleClass with mutual-exclusion ScrollTrigger callbacks (single-point start/end center), removed translateY(-2px) from active state, added highlight class cleanup on unmount, added will-change: opacity, and covered both .v9-pricing-tier and .v9-pricing-name in the reduced-motion block.
 ## Evidence
-- Commits:
-- Tests:
+- Commits: 3eb7ea2d190c2398e0a49bf96d0aaf11da3c64d0
+- Tests: npx tsc --noEmit, npm test (vitest run — 2 tests passed)
 - PRs:

--- a/.flow/tasks/fn-4-mgl.2.md
+++ b/.flow/tasks/fn-4-mgl.2.md
@@ -1,0 +1,56 @@
+# fn-4-mgl.2 Fix Pricing.tsx: mutual exclusion, translateY, cleanup, will-change, reduced-motion
+
+## Description
+Fix all visual/animation bugs in `app/_home/components/Pricing.tsx`.
+
+**Size:** M
+**Files:** `app/_home/components/Pricing.tsx` only
+**Blast zone:** Only `app/_home/page.tsx` imports this component. `trackPricingView` (line 115) and `trackCTAClick` (line 203) calls are unchanged — no analytics impact.
+
+### Approach
+
+1. **Mutual exclusion — single-point triggers**: Replace the per-row independent `ScrollTrigger.create` with `toggleClass` (lines 130-137) with a `prevActive` index tracker. Create one ScrollTrigger per row using `start: 'top center'` and `end: 'bottom center'` (explicit symmetric points). Use callbacks — NOT `toggleClass`:
+
+   - `onEnter` (scrolling down, row top crosses center): strip `v9-pricing-tier--active` from ALL rows, add it to THIS row.
+   - `onEnterBack` (scrolling up, row bottom crosses center going up): strip ALL, add to THIS row.
+   - `onLeaveBack` (scrolling up past first row only): strip ALL rows (no row should be active above the section). Only fire cleanup on first row (`i === 0`).
+   - `onLeave` (scrolling down past last row only): strip ALL rows. Only fire on last row (`i === rowsArr.length - 1`).
+
+   **CRITICAL**: Do NOT use `onLeave` on intermediate rows to strip classes — if `onLeave` for row N fires after `onEnter` for row N+1, it will incorrectly deactivate the newly activated row. Only the boundary rows (first/last) need deactivation callbacks.
+
+   `rowsArr` is derived from `querySelectorAll` — if empty, `forEach` skips silently (safe).
+
+2. **Remove translateY**: Remove `transform: translateY(-2px)` from `.v9-pricing-tier--active` (line 519). Also remove `transform 0.4s cubic-bezier(0.16, 1, 0.3, 1),` from the `.v9-pricing-tier` transition list (line 507). The `.v9-btn-gradient:hover { transform: translateY(-2px) }` (line 441) is a different element and is unaffected.
+
+3. **Highlight class cleanup (option A)**: `v9-pricing--highlight` is added via `once: true` callback (line 127) and `ctx.revert()` does NOT remove it. Change `return () => ctx.revert()` at line 140 to `return () => { ctx.revert(); section.classList.remove('v9-pricing--highlight'); }`. `section` is non-null at this point (guarded by line 67).
+
+4. **will-change**: Add `will-change: opacity` to `.v9-pricing-tier` CSS rule (lines 289-293). Do NOT add `will-change: transform` — transform is being removed from the active state entirely; promoting a compositor layer for it wastes GPU memory.
+
+5. **Reduced-motion transition fix**: In `@media (prefers-reduced-motion: reduce)` block (lines 526-533), add `transition: none !important` to the existing selector. Also add `.v9-pricing-tier .v9-pricing-name` to the selector — it has `transition: color 0.4s cubic-bezier(...)` at lines 511-513, currently not covered.
+
+### Key context
+
+- **Mutual exclusion callback ordering**: `onLeave` on row N and `onEnter` on row N+1 can fire at the same scroll position (when their trigger points coincide). Stripping from `onLeave` on intermediate rows risks removing the class that `onEnter` just added on the next row. Solution: only strip on boundary rows (first row's `onLeaveBack`, last row's `onLeave`). All other activation uses `onEnter`/`onEnterBack`.
+- **`start: 'top center'` / `end: 'bottom center'`**: Row becomes active when its top crosses viewport center going down; deactivates when its bottom crosses viewport center going down. This creates a clean single-row active zone with no overlap.
+- **`ctx.revert()` and `toggleClass`**: `ctx.revert()` DOES revert class changes made via GSAP's `toggleClass` option. But it does NOT revert `section.classList.add()` made in raw JS callbacks — hence the explicit `classList.remove` in cleanup.
+- `trackPricingView` at line 115 fires on scroll entry of the entrance trigger — unrelated to highlight logic, leave it untouched.
+- CSS regression: removing `transform` from transition list is safe — no other transforms are set on `.v9-pricing-tier`. The button hover transform (line 441) is a different selector.
+- Refs: lines 122-137 (triggers), 289-293 (tier CSS), 503-525 (highlight CSS), 526-533 (reduced-motion), 511-513 (.v9-pricing-name transition).
+
+## Acceptance
+
+- [ ] Only one Pricing row is active at a time — verified by scrolling slowly down through all three tiers
+- [ ] No "dead zone" — as one row exits active state, the next immediately becomes active
+- [ ] Scrolling UP through Pricing highlights each row correctly (bidirectional, onEnterBack works)
+- [ ] Scrolling back above the Pricing section: `v9-pricing--highlight` is removed from section (verify in DevTools)
+- [ ] No row shifts upward — borders stay aligned, no translateY bleed
+- [ ] TypeScript: no errors (`npx tsc --noEmit`)
+- [ ] Reduced-motion: all highlight transitions are instant — no smooth fade on opacity or color for `.v9-pricing-tier` or `.v9-pricing-name`
+
+## Done summary
+TBD
+
+## Evidence
+- Commits:
+- Tests:
+- PRs:

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,7 @@
     "claude-flow": {
       "command": "npx",
       "args": [
+        "-y",
         "@claude-flow/cli@latest",
         "mcp",
         "start"

--- a/app/_home/components/Pricing.tsx
+++ b/app/_home/components/Pricing.tsx
@@ -143,9 +143,7 @@ export function Pricing() {
           onLeaveBack: i === 0 ? () => {
             rowsArr.forEach((r) => r.classList.remove('v9-pricing-tier--active'));
           } : undefined,
-          onLeave: i === rowsArr.length - 1 ? () => {
-            rowsArr.forEach((r) => r.classList.remove('v9-pricing-tier--active'));
-          } : undefined,
+          onLeave: () => { row.classList.remove('v9-pricing-tier--active'); },
         });
       });
     }, section);

--- a/app/_home/components/Pricing.tsx
+++ b/app/_home/components/Pricing.tsx
@@ -127,17 +127,30 @@ export function Pricing() {
         onEnter: () => section.classList.add('v9-pricing--highlight'),
       });
 
-      rowsArr.forEach((row) => {
+      rowsArr.forEach((row, i) => {
         ScrollTrigger.create({
           trigger: row,
-          start: 'top 60%',
-          end: 'bottom 40%',
-          toggleClass: { targets: row, className: 'v9-pricing-tier--active' },
+          start: 'top center',
+          end: 'bottom center',
+          onEnter: () => {
+            rowsArr.forEach((r) => r.classList.remove('v9-pricing-tier--active'));
+            row.classList.add('v9-pricing-tier--active');
+          },
+          onEnterBack: () => {
+            rowsArr.forEach((r) => r.classList.remove('v9-pricing-tier--active'));
+            row.classList.add('v9-pricing-tier--active');
+          },
+          onLeaveBack: i === 0 ? () => {
+            rowsArr.forEach((r) => r.classList.remove('v9-pricing-tier--active'));
+          } : undefined,
+          onLeave: i === rowsArr.length - 1 ? () => {
+            rowsArr.forEach((r) => r.classList.remove('v9-pricing-tier--active'));
+          } : undefined,
         });
       });
     }, section);
 
-    return () => ctx.revert();
+    return () => { ctx.revert(); section.classList.remove('v9-pricing--highlight'); };
   }, []);
 
   return (
@@ -290,6 +303,7 @@ export function Pricing() {
           display: grid;
           grid-template-columns: minmax(min(200px, 100%), 240px) 1fr minmax(min(200px, 100%), 260px);
           border-bottom: 1px solid rgba(12, 17, 23, 0.07);
+          will-change: opacity;
         }
 
         /* Left: identity */
@@ -504,7 +518,6 @@ export function Pricing() {
           opacity: 0.65;
           transition: opacity 0.4s cubic-bezier(0.16, 1, 0.3, 1),
                       box-shadow 0.4s cubic-bezier(0.16, 1, 0.3, 1),
-                      transform 0.4s cubic-bezier(0.16, 1, 0.3, 1),
                       background 0.4s cubic-bezier(0.16, 1, 0.3, 1);
         }
 
@@ -516,7 +529,6 @@ export function Pricing() {
           opacity: 1;
           box-shadow: inset 4px 0 0 #0B8A6E;
           background: rgba(11, 138, 110, 0.03);
-          transform: translateY(-2px);
         }
 
         .v9-pricing--highlight .v9-pricing-tier--active .v9-pricing-name {
@@ -529,6 +541,11 @@ export function Pricing() {
           .v9-pricing-tier {
             opacity: 1 !important;
             transform: none !important;
+            transition: none !important;
+          }
+
+          .v9-pricing--highlight .v9-pricing-tier .v9-pricing-name {
+            transition: none !important;
           }
         }
       `}</style>

--- a/app/_home/components/Services.tsx
+++ b/app/_home/components/Services.tsx
@@ -118,22 +118,29 @@ export function Services() {
 
         const animateBullets = (col: HTMLElement) => {
           const bullets = col.querySelectorAll<HTMLElement>('.v9-lever-bullets li');
+          gsap.killTweensOf(bullets);
           gsap.fromTo(bullets,
             { opacity: 0, x: -6 },
-            { opacity: 1, x: 0, duration: 0.25, stagger: 0.04, ease: 'power2.out' }
+            { opacity: 1, x: 0, duration: 0.25, stagger: 0.04, ease: 'power2.out', overwrite: 'auto' }
           );
         };
 
         ScrollTrigger.create({
           trigger: section,
           start: 'top top',
-          end: '+=150%',
+          end: '+=120%',
           pin: true,
           scrub: 0.6,
           onEnter: () => {
             section.classList.add('v9-services--highlight');
             cols.forEach((col, i) => col.classList.toggle('v9-lever-col--active', i === 0));
             prevActive = 0;
+            animateBullets(cols[0]);
+          },
+          onLeave: () => {
+            section.classList.remove('v9-services--highlight');
+            cols.forEach((col) => col.classList.remove('v9-lever-col--active'));
+            prevActive = -1;
           },
           onLeaveBack: () => {
             section.classList.remove('v9-services--highlight');
@@ -152,7 +159,7 @@ export function Services() {
       }
     }, section);
 
-    return () => ctx.revert();
+    return () => { ctx.revert(); section.classList.remove('v9-services--highlight'); };
   }, []);
 
   return (
@@ -252,19 +259,16 @@ export function Services() {
         }
 
         .v9-lever-col {
-          padding: 40px 28px 40px 0;
+          padding: 40px 28px 40px 28px;
           border-right: 1px solid rgba(12, 17, 23, 0.08);
           display: flex;
           flex-direction: column;
+          will-change: opacity, transform;
         }
 
         .v9-lever-col:last-child {
           border-right: none;
           padding-right: 0;
-        }
-
-        .v9-lever-col:not(:first-child) {
-          padding-left: 28px;
         }
 
         .v9-lever-num {
@@ -365,7 +369,7 @@ export function Services() {
 
           .v9-lever-col:nth-child(3) {
             border-right: 1px solid rgba(12, 17, 23, 0.08);
-            padding-left: 0;
+            padding-left: 28px;
             padding-top: 40px;
             border-top: 1px solid rgba(12, 17, 23, 0.08);
           }
@@ -406,7 +410,7 @@ export function Services() {
         /* Scroll highlight */
         .v9-services--highlight .v9-lever-col {
           opacity: 0.65;
-          transition: opacity 0.35s linear, box-shadow 0.35s linear, transform 0.35s linear;
+          transition: opacity 0.35s linear, box-shadow 0.35s linear;
         }
 
         .v9-services--highlight .v9-lever-col .v9-lever-title {
@@ -416,7 +420,6 @@ export function Services() {
         .v9-services--highlight .v9-lever-col--active {
           opacity: 1;
           box-shadow: inset 3px 0 0 #0B8A6E;
-          transform: translateY(-2px);
         }
 
         .v9-services--highlight .v9-lever-col--active .v9-lever-title {
@@ -425,9 +428,11 @@ export function Services() {
 
         @media (prefers-reduced-motion: reduce) {
           .v9-services-header,
-          .v9-lever-col {
+          .v9-lever-col,
+          .v9-lever-col .v9-lever-title {
             opacity: 1 !important;
             transform: none !important;
+            transition: none !important;
           }
         }
       `}</style>

--- a/app/_home/components/Services.tsx
+++ b/app/_home/components/Services.tsx
@@ -263,7 +263,7 @@ export function Services() {
           border-right: 1px solid rgba(12, 17, 23, 0.08);
           display: flex;
           flex-direction: column;
-          will-change: opacity, transform;
+          will-change: opacity;
         }
 
         .v9-lever-col:last-child {


### PR DESCRIPTION
## Summary

- **Services.tsx**: equal 28px left padding on all cols, `animateBullets` on initial enter + `killTweensOf`, `onLeave` cleanup handler, mobile `v9-services--highlight` removal on unmount, pin end `120%`, no `translateY(-2px)` on active col, `will-change: opacity`, reduced-motion covers `.v9-lever-title`
- **Pricing.tsx**: mutual-exclusion ScrollTrigger (single-point `top center`/`bottom center`, boundary sweeps + per-row `onLeave` for short-row gap), no `translateY(-2px)` on active tier, highlight class cleanup on unmount, `will-change: opacity`, reduced-motion covers `.v9-pricing-name`

## Test plan

- [ ] `npx tsc --noEmit` passes (no TS errors)
- [ ] `npm run build` succeeds
- [ ] Vitest 2/2 green
- [ ] Col 01 green bar inset (not flush with section edge) at desktop
- [ ] All 4 cols have equal left padding; col 03 inset at 1024px
- [ ] On initial scroll-enter, col 01 bullets animate in
- [ ] Fast back/forth scrub — no flashing or stuck-at-0 bullets
- [ ] Forward scroll past pin zone: no col stays highlighted
- [ ] Scroll back above section: no col stays highlighted
- [ ] Pricing: only one tier active at a time scrolling down and up
- [ ] Short/wide-viewport: no pricing tier stays stuck active between rows
- [ ] Active col/tier does not shift upward (no border bleed)
- [ ] Reduced-motion: instant opacity/color changes, no transition on `.v9-lever-col`, `.v9-lever-title`, `.v9-pricing-tier`, `.v9-pricing-name`