### PR TITLE
fix(copy): shorten footer bio

### DIFF
--- a/app/_home/components/ContactSection.tsx
+++ b/app/_home/components/ContactSection.tsx
@@ -65,19 +65,17 @@ export function ContactSection() {
         className="v1-contact v9-section-dark"
       >
         <div className="v1-wrap">
-
           {/* Above-grid header */}
           <div className="v1-contact-header">
             <p className="v1-eyebrow">Contact</p>
             <h2 className="v1-contact-heading">
               Let&apos;s figure out what would work for your business
             </h2>
-            <p className="v1-contact-sub">30 minutes. No pitch.</p>
+            <p className="v1-contact-sub">30 minutes.</p>
           </div>
 
           {/* Side-by-side grid */}
           <div className="v1-contact-grid">
-
             {/* Left: Cal embed */}
             <div className="v1-cal-col">
               <div className="v1-cal-label-row">
@@ -122,9 +120,8 @@ export function ContactSection() {
               </p>
 
               <p className="v1-bio-body">
-                Since 2013, 100+ projects for small and mid-size businesses.
-                You work directly with me &mdash; not an account manager &mdash;
-                backed by a network of professionals I&apos;ve worked alongside for years.
+                Since 2013, 100+ projects for small and mid-size businesses. You
+                work directly with me.
               </p>
 
               <div className="v1-bio-stats">
@@ -147,7 +144,17 @@ export function ContactSection() {
                   onClick={() => trackContactClick('email')}
                 >
                   <div className="v1-contact-icon">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <svg
+                      width="20"
+                      height="20"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
                       <rect x="2" y="4" width="20" height="16" rx="2" />
                       <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
                     </svg>
@@ -165,7 +172,13 @@ export function ContactSection() {
                   onClick={() => trackContactClick('linkedin')}
                 >
                   <div className="v1-contact-icon">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <svg
+                      width="20"
+                      height="20"
+                      viewBox="0 0 24 24"
+                      fill="currentColor"
+                      aria-hidden="true"
+                    >
                       <path d="M20.5 2h-17A1.5 1.5 0 0 0 2 3.5v17A1.5 1.5 0 0 0 3.5 22h17a1.5 1.5 0 0 0 1.5-1.5v-17A1.5 1.5 0 0 0 20.5 2zM8 19H5v-9h3zM6.5 8.25A1.75 1.75 0 1 1 8.3 6.5a1.78 1.78 0 0 1-1.8 1.75zM19 19h-3v-4.74c0-1.42-.6-1.93-1.38-1.93A1.74 1.74 0 0 0 13 14.19a.66.66 0 0 0 0 .14V19h-3v-9h2.9v1.3a3.11 3.11 0 0 1 2.7-1.4c1.55 0 3.36.86 3.36 3.66z" />
                     </svg>
                   </div>
@@ -177,10 +190,8 @@ export function ContactSection() {
               </div>
             </div>
             {/* /bio-col */}
-
           </div>
           {/* /contact-grid */}
-
         </div>
       </section>
 


### PR DESCRIPTION
Removes 'not an account manager' and 'backed by a network of professionals' from footer bio. Keeps: 'Since 2013, 100+ projects for small and mid-size businesses. You work directly with me.'