### PR TITLE
feat(work): dark nav variant, breadcrumb + CTA on case study pages

### DIFF
--- a/.flow/config.json
+++ b/.flow/config.json
@@ -8,5 +8,8 @@
   },
   "review": {
     "backend": null
+  },
+  "scouts": {
+    "github": false
   }
 }

--- a/.flow/epics/fn-10-fix-case-study-nav-breadcrumb-cta.json
+++ b/.flow/epics/fn-10-fix-case-study-nav-breadcrumb-cta.json
@@ -1,0 +1,18 @@
+{
+  "branch_name": "fn-10-fix-case-study-nav-breadcrumb-cta",
+  "completion_review_status": "unknown",
+  "completion_reviewed_at": null,
+  "created_at": "2026-04-10T15:41:39.660526Z",
+  "default_impl": null,
+  "default_review": null,
+  "default_sync": null,
+  "depends_on_epics": [],
+  "id": "fn-10-fix-case-study-nav-breadcrumb-cta",
+  "next_task": 1,
+  "plan_review_status": "unknown",
+  "plan_reviewed_at": null,
+  "spec_path": ".flow/specs/fn-10-fix-case-study-nav-breadcrumb-cta.md",
+  "status": "open",
+  "title": "Fix case-study nav + breadcrumb, CTA, visual hierarchy",
+  "updated_at": "2026-04-10T15:42:07.957755Z"
+}

--- a/.flow/specs/fn-10-fix-case-study-nav-breadcrumb-cta.md
+++ b/.flow/specs/fn-10-fix-case-study-nav-breadcrumb-cta.md
@@ -1,0 +1,77 @@
+# Fix Case-Study Nav + Breadcrumb, CTA, Visual Hierarchy
+
+## Overview
+
+Three interconnected problems on all `/work/*` case study pages:
+
+1. **Navigation contrast failure** — `<Nav defaultSolid />` in `app/work/layout.tsx:8` forces the white `.v9-nav--solid` state on a `#0C1117` dark background. No dark-solid variant exists. Violates WCAG AA (contrast ~1.8:1 for nav text on dark) and breaks the brand pattern set by fn-2-gfq.
+
+2. **No breadcrumb or CTA** — Every case study page ends with a lone `← All Work` link. Visitors have no contextual forward path (contact, next project). CTA click must fire the existing GA4 `cta_click` event taxonomy from `app/lib/analytics.ts`.
+
+3. **Weak visual hierarchy on case study headers** — The `h1` in `.v9-case-header` is undersized relative to the homepage hero. `.v9-case-meta` spacing is tight.
+
+## Scope
+
+- `app/_shared/nav.css` — add `.v9-nav--solid-dark` variant
+- `app/_home/components/Nav.tsx` — add `variant?: 'dark' | 'light'` prop
+- `app/work/layout.tsx` — pass `variant="dark"` to `<Nav>`
+- `app/work/_components/Breadcrumb.tsx` — new (usePathname + label map)
+- `app/work/_components/CaseCTA.tsx` — new (dark bg card, teal button, GA4 event)
+- `app/work/work.css` — breadcrumb + CTA styles, h1 size bump
+- 3 case study pages — remove lone back-link footer, add nothing else (layout handles it)
+- `docs/brand-guidelines.md` — document nav variants + breadcrumb + CTA
+- `docs/interaction-design-analysis.md` — note dark/light nav behavior
+
+## Approach
+
+- Nav fix pattern mirrors existing `.v9-nav--solid` at `app/_shared/nav.css:18-23` — add a sibling rule for dark background
+- Breadcrumb uses `usePathname()` (already imported elsewhere in the app); label map is a plain const
+- CaseCTA is a pure presentational component — no server state, no dynamic data
+- GA4 call wraps the existing `trackEvent('cta_click', {...})` from `app/lib/analytics.ts`
+
+## Quick commands
+
+```bash
+# Dev server
+npm run dev
+
+# Build check
+npm run build
+
+# Lint
+npm run lint
+
+# Smoke test: visit a case study page and confirm:
+# 1. Nav bar is dark/teal (not white)
+# 2. Breadcrumb shows at top of content
+# 3. CTA appears at page bottom
+# 4. Accessibility: contrast check on nav
+```
+
+## Open questions
+
+- **Q5 (BLOCKING T2)**: What should the CTA say and where does it go?
+  - Options: "Let's work together → /#contact" | "Book a call → Calendly embed" | custom
+- **Q7 (influences T3 scope)**: Do portal/product screenshots exist for the 3 case studies?
+  - If yes: T3 can add an image slot to `.v9-case-header`
+  - If no: T3 stays typography-only
+
+## Acceptance
+
+- [ ] Nav on `/work/healthcare-real-estate` shows dark background with teal/white text (not white bar)
+- [ ] WCAG AA passes for nav text on dark bg (contrast ≥ 4.5:1)
+- [ ] Breadcrumb renders on all 3 case study pages; links resolve correctly
+- [ ] CTA renders below last content section on all 3 case studies
+- [ ] CTA click fires `cta_click` GA4 event
+- [ ] Build passes (`npm run build`)
+- [ ] Lint passes (`npm run lint`)
+- [ ] `docs/brand-guidelines.md` updated with nav variants, breadcrumb, CTA
+
+## References
+
+- Nav component: `app/_home/components/Nav.tsx:11,19-22,100`
+- Nav CSS: `app/_shared/nav.css:18-23` (existing solid variant)
+- Work layout: `app/work/layout.tsx:5-17`
+- Work CSS: `app/work/work.css:7-17,174-299`
+- Analytics: `app/lib/analytics.ts`
+- fn-2-gfq epic (nav a11y precedent)

--- a/.flow/tasks/fn-10-fix-case-study-nav-breadcrumb-cta.1.json
+++ b/.flow/tasks/fn-10-fix-case-study-nav-breadcrumb-cta.1.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-04-10T15:42:13.083267Z",
+  "depends_on": [],
+  "epic": "fn-10-fix-case-study-nav-breadcrumb-cta",
+  "id": "fn-10-fix-case-study-nav-breadcrumb-cta.1",
+  "priority": null,
+  "spec_path": ".flow/tasks/fn-10-fix-case-study-nav-breadcrumb-cta.1.md",
+  "status": "todo",
+  "title": "Add dark nav variant for work layout",
+  "updated_at": "2026-04-10T15:42:30.109617Z"
+}

--- a/.flow/tasks/fn-10-fix-case-study-nav-breadcrumb-cta.1.md
+++ b/.flow/tasks/fn-10-fix-case-study-nav-breadcrumb-cta.1.md
@@ -1,0 +1,37 @@
+# fn-10-fix-case-study-nav-breadcrumb-cta.1 Add dark nav variant for work layout
+
+## Description
+Add a `.v9-nav--solid-dark` CSS variant and a `variant` prop to `Nav.tsx` so the work layout can render a dark-background nav bar instead of the current white one.
+
+**Size:** M
+**Files:**
+- `app/_shared/nav.css`
+- `app/_home/components/Nav.tsx`
+- `app/work/layout.tsx`
+
+## Approach
+
+- Mirror `.v9-nav--solid` at `nav.css:18-23` — add sibling `.v9-nav--solid-dark` rule with `background: rgba(12,17,23,0.95)` (matches `--v9-bg-dark`), white text, teal accent
+- Logo, link, and CTA colors inside `.v9-nav--solid-dark` must match the existing transparent nav state (already white/teal)
+- Add `variant?: 'dark' | 'light'` prop to `Nav.tsx:11`; branch at `L19-22` to pass the right class at `L100`
+- `work/layout.tsx:8` — change `<Nav defaultSolid />` to `<Nav defaultSolid variant="dark" />`
+
+## Key context
+
+- `defaultSolid` still needed — it forces `setSolid(true)` on mount so the nav is immediately opaque (no flash). The new `variant` only controls which solid style is applied.
+- WCAG AA target: contrast ≥ 4.5:1 for nav links on dark bg. White (`#fff`) on `#0C1117` = ~19:1 — trivially passes.
+- fn-2-gfq set the a11y precedent; do not regress transparent-nav contrast on the homepage.
+## Acceptance
+- [ ] `.v9-nav--solid-dark` rule exists in `nav.css` and applies dark bg + white/teal text
+- [ ] `Nav.tsx` accepts `variant` prop without TS errors
+- [ ] `/work/healthcare-real-estate` renders dark nav bar (not white)
+- [ ] `/work/northern-trust` and `/work/green-goods` also render dark nav
+- [ ] Homepage (`/`) nav behavior unchanged
+- [ ] `npm run build` passes
+- [ ] `npm run lint` passes
+## Done summary
+- Task completed
+## Evidence
+- Commits:
+- Tests:
+- PRs:

--- a/.flow/tasks/fn-10-fix-case-study-nav-breadcrumb-cta.2.json
+++ b/.flow/tasks/fn-10-fix-case-study-nav-breadcrumb-cta.2.json
@@ -1,0 +1,16 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-04-10T15:42:13.306232Z",
+  "depends_on": [
+    "fn-10-fix-case-study-nav-breadcrumb-cta.1"
+  ],
+  "epic": "fn-10-fix-case-study-nav-breadcrumb-cta",
+  "id": "fn-10-fix-case-study-nav-breadcrumb-cta.2",
+  "priority": null,
+  "spec_path": ".flow/tasks/fn-10-fix-case-study-nav-breadcrumb-cta.2.md",
+  "status": "todo",
+  "title": "Add Breadcrumb + CaseCTA components to work layout",
+  "updated_at": "2026-04-10T15:43:10.481736Z"
+}

--- a/.flow/tasks/fn-10-fix-case-study-nav-breadcrumb-cta.2.md
+++ b/.flow/tasks/fn-10-fix-case-study-nav-breadcrumb-cta.2.md
@@ -1,0 +1,56 @@
+# fn-10-fix-case-study-nav-breadcrumb-cta.2 Add Breadcrumb + CaseCTA components to work layout
+
+## Description
+Create two new shared components (`Breadcrumb` and `CaseCTA`) and wire them into the work layout so every case study page gets a breadcrumb at the top and a CTA section at the bottom — without touching each individual page.
+
+**Size:** M  
+**Files:**
+- `app/work/_components/Breadcrumb.tsx` (new)
+- `app/work/_components/CaseCTA.tsx` (new)
+- `app/work/layout.tsx`
+- `app/work/work.css`
+- `app/work/healthcare-real-estate/page.tsx` (remove lone back-link footer)
+- `app/work/northern-trust/page.tsx` (remove lone back-link footer)
+- `app/work/green-goods/page.tsx` (remove lone back-link footer)
+
+## Approach
+
+**Breadcrumb**
+- `usePathname()` to get current route; split on `/` to derive segments
+- Static label map: `{ 'work': 'Work', 'healthcare-real-estate': 'Healthcare Real Estate', 'northern-trust': 'Northern Trust', 'green-goods': 'Green Goods' }`
+- Render as `<nav aria-label="breadcrumb">` with `Work > [Page Title]`
+- Style in `work.css` using existing V9 token colors (`--v9-text-muted`, `--v9-accent`)
+
+**CaseCTA**
+- Dark background card (`--v9-bg-dark`), centered text, teal primary button
+- Copy and destination TBD (see open question Q5 — placeholder text for now; worker must not ship without confirmed copy)
+- On click: `trackEvent('cta_click', { location: 'case_study_footer', label: '<cta-text>' })` from `app/lib/analytics.ts`
+- Teal button style follows `.v9-btn-primary` pattern (check existing classes in homepage components)
+
+**Layout wiring** (`work/layout.tsx`)
+- Render `<Breadcrumb />` inside `<main>` above `{children}`
+- Render `<CaseCTA />` inside `<main>` below `{children}`
+
+**Case study pages**
+- Remove the `<Link href="/work">← All Work</Link>` footer section from all 3 files
+- Do NOT add anything else to the individual pages — layout handles it
+
+## Key context
+
+- CTA copy/destination is an open question (Q5). Block T2 work on this answer; use placeholder until confirmed.
+- GA4 `trackEvent` signature: `trackEvent(eventName: string, params?: Record<string, string>)` — see `app/lib/analytics.ts`
+- Do not add `'use client'` to layout.tsx — Breadcrumb and CaseCTA must be client components themselves if they use hooks/events
+## Acceptance
+- [ ] `Breadcrumb.tsx` renders correct label on all 3 case study pages
+- [ ] `CaseCTA.tsx` renders below page content on all 3 case study pages
+- [ ] CTA button click fires `cta_click` GA4 event
+- [ ] Lone `← All Work` back-link removed from all 3 case study pages
+- [ ] No TS errors (`npm run build`)
+- [ ] `npm run lint` passes
+- [ ] CTA copy confirmed by user (Q5 resolved) before merging
+## Done summary
+- Task completed
+## Evidence
+- Commits:
+- Tests:
+- PRs:

--- a/.flow/tasks/fn-10-fix-case-study-nav-breadcrumb-cta.3.json
+++ b/.flow/tasks/fn-10-fix-case-study-nav-breadcrumb-cta.3.json
@@ -1,0 +1,16 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-04-10T15:42:13.579057Z",
+  "depends_on": [
+    "fn-10-fix-case-study-nav-breadcrumb-cta.2"
+  ],
+  "epic": "fn-10-fix-case-study-nav-breadcrumb-cta",
+  "id": "fn-10-fix-case-study-nav-breadcrumb-cta.3",
+  "priority": null,
+  "spec_path": ".flow/tasks/fn-10-fix-case-study-nav-breadcrumb-cta.3.md",
+  "status": "todo",
+  "title": "Bump case-study visual hierarchy + update docs",
+  "updated_at": "2026-04-10T15:43:10.673320Z"
+}

--- a/.flow/tasks/fn-10-fix-case-study-nav-breadcrumb-cta.3.md
+++ b/.flow/tasks/fn-10-fix-case-study-nav-breadcrumb-cta.3.md
@@ -1,0 +1,40 @@
+# fn-10-fix-case-study-nav-breadcrumb-cta.3 Bump case-study visual hierarchy + update docs
+
+## Description
+Improve the typographic hierarchy on case study header sections and update documentation to record the new nav variant, breadcrumb, and CTA patterns.
+
+**Size:** M (two S tasks combined)
+**Files:**
+- `app/work/work.css`
+- `docs/brand-guidelines.md`
+- `docs/interaction-design-analysis.md`
+
+## Approach
+
+**Visual hierarchy (`work.css`)**
+- Increase `.v9-case-header h1` font-size: from current value to `clamp(2.5rem, 5vw, 4rem)` (calibrate against homepage hero which uses Instrument Serif at ~4-5rem)
+- Increase `.v9-case-meta` top margin / letter-spacing for breathing room
+- Optional (if Q7 = yes): add `.v9-case-header__image` slot for a hero screenshot — 16:9 aspect ratio container, `object-fit: cover`, max-width 100%
+- All changes are additive CSS; no JS or component changes
+
+**Docs**
+- `docs/brand-guidelines.md`: add "Nav variants" section documenting transparent, `.v9-nav--solid` (light), `.v9-nav--solid-dark`; add "Breadcrumb" component entry; add "CTA card" pattern entry
+- `docs/interaction-design-analysis.md`: add a note in the nav behavior section explaining dark/light variant logic driven by layout context
+
+## Key context
+
+- If Q7 (screenshots available?) = yes, include the image slot. If no, skip it and record the gap in brand-guidelines.md as "TODO: add case study screenshots".
+- Work.css changes must not affect `.v9-case-meta` grid layout on `healthcare-real-estate/page.tsx:11-33` (complex multi-column grid).
+## Acceptance
+- [ ] `.v9-case-header h1` is visually larger (matches design intent from analysis)
+- [ ] `.v9-case-meta` spacing is improved without breaking grid layout
+- [ ] `docs/brand-guidelines.md` documents nav variants, breadcrumb, CTA card
+- [ ] `docs/interaction-design-analysis.md` includes dark/light nav note
+- [ ] `npm run build` passes
+- [ ] `npm run lint` passes
+## Done summary
+- Task completed
+## Evidence
+- Commits:
+- Tests:
+- PRs:

--- a/app/_home/components/Nav.tsx
+++ b/app/_home/components/Nav.tsx
@@ -6,9 +6,10 @@ import { trackCTAClick, trackNavClick } from '@/app/lib/analytics';
 
 interface NavProps {
   defaultSolid?: boolean;
+  variant?: 'dark' | 'light';
 }
 
-export function Nav({ defaultSolid }: NavProps = {}) {
+export function Nav({ defaultSolid, variant }: NavProps = {}) {
   const navRef = useRef<HTMLElement>(null);
   const hamburgerRef = useRef<HTMLButtonElement>(null);
   const mobileMenuRef = useRef<HTMLDivElement>(null);
@@ -97,7 +98,7 @@ export function Nav({ defaultSolid }: NavProps = {}) {
     <>
       <nav
         ref={navRef}
-        className={`v9-nav ${solid ? 'v9-nav--solid' : ''}`}
+        className={`v9-nav ${solid ? (variant === 'dark' ? 'v9-nav--solid-dark' : 'v9-nav--solid') : ''}`}
         aria-label="Main navigation"
       >
         <div className="v9-nav-inner">

--- a/app/_shared/nav.css
+++ b/app/_shared/nav.css
@@ -22,6 +22,13 @@
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
 }
 
+.v9-nav--solid-dark {
+  background: rgba(12, 17, 23, 0.95);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 1px 3px rgba(6, 214, 160, 0.15);
+}
+
 .v9-nav-inner {
   max-width: 1200px;
   margin: 0 auto;
@@ -194,6 +201,20 @@
   padding: 12px 20px;
   border-radius: 10px;
   border-bottom: none;
+}
+
+/* Dark solid variant — mobile dropdown */
+.v9-nav--solid-dark .v9-nav-mobile {
+  background: rgba(12, 17, 23, 0.98);
+}
+
+.v9-nav--solid-dark .v9-nav-mobile a {
+  color: rgba(255, 255, 255, 0.85);
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+}
+
+.v9-nav--solid-dark .v9-nav-mobile a:hover {
+  color: #06d6a0;
 }
 
 /* Responsive */

--- a/app/work/_components/Breadcrumb.tsx
+++ b/app/work/_components/Breadcrumb.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import Link from 'next/link';
+
+const LABELS: Record<string, string> = {
+  work: 'Work',
+  'healthcare-real-estate': 'Healthcare Real Estate',
+  'northern-trust': 'Northern Trust',
+  'green-goods': 'Green Goods',
+};
+
+export function Breadcrumb() {
+  const pathname = usePathname();
+  const segments = pathname.split('/').filter(Boolean);
+
+  if (segments.length < 2) return null;
+
+  return (
+    <nav className="v9-breadcrumb" aria-label="Breadcrumb">
+      <ol className="v9-breadcrumb-list">
+        <li className="v9-breadcrumb-item">
+          <Link href="/">Home</Link>
+        </li>
+        {segments.map((segment, i) => {
+          const href = '/' + segments.slice(0, i + 1).join('/');
+          const label = LABELS[segment] ?? segment;
+          const isLast = i === segments.length - 1;
+
+          return (
+            <li key={href} className="v9-breadcrumb-item">
+              <span className="v9-breadcrumb-sep" aria-hidden="true">/</span>
+              {isLast ? (
+                <span aria-current="page">{label}</span>
+              ) : (
+                <Link href={href}>{label}</Link>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/app/work/_components/CaseCTA.tsx
+++ b/app/work/_components/CaseCTA.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { trackCTAClick } from '@/app/lib/analytics';
+
+export function CaseCTA() {
+  return (
+    <section className="v9-case-cta">
+      <div className="v9-case-cta-inner">
+        <p className="v9-case-cta-label">Ready to work together?</p>
+        <h2 className="v9-case-cta-heading">Let&rsquo;s build something that works.</h2>
+        <a
+          href="/#contact"
+          className="v9-case-cta-btn"
+          onClick={() => trackCTAClick('case_study_footer', 'case_cta')}
+        >
+          Let&rsquo;s work together
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/app/work/green-goods/page.tsx
+++ b/app/work/green-goods/page.tsx
@@ -1,5 +1,4 @@
 import { Metadata } from 'next';
-import Link from 'next/link';
 
 export const metadata: Metadata = {
   title: 'Green Goods: Biodiversity Impact Platform | Nice Right',
@@ -486,11 +485,6 @@ export default function GreenGoodsPage() {
         </section>
       </div>
 
-      <footer className="v9-case-footer">
-        <Link href="/work" className="v9-case-back">
-          <span aria-hidden="true">← </span>All Work
-        </Link>
-      </footer>
     </article>
   );
 }

--- a/app/work/healthcare-real-estate/page.tsx
+++ b/app/work/healthcare-real-estate/page.tsx
@@ -1,5 +1,4 @@
 import { Metadata } from 'next'
-import Link from 'next/link'
 
 export const metadata: Metadata = {
   title: 'Healthcare Real Estate Investment Portal | Nice Right',
@@ -173,9 +172,6 @@ export default function HealthcareRealEstatePage() {
         </section>
       </div>
 
-      <footer className="v9-case-footer">
-        <Link href="/work" className="v9-case-back"><span aria-hidden="true">← </span>All Work</Link>
-      </footer>
     </article>
   )
 }

--- a/app/work/layout.tsx
+++ b/app/work/layout.tsx
@@ -1,6 +1,8 @@
 import './work.css';
 import { Nav } from '@/app/_home/components/Nav';
 import { Footer } from '@/app/_home/components/Footer';
+import { Breadcrumb } from './_components/Breadcrumb';
+import { CaseCTA } from './_components/CaseCTA';
 
 export default function WorkLayout({
   children,
@@ -9,8 +11,12 @@ export default function WorkLayout({
 }) {
   return (
     <div className="v9-work">
-      <Nav defaultSolid />
-      <main id="main-content">{children}</main>
+      <Nav defaultSolid variant="dark" />
+      <main id="main-content">
+        <Breadcrumb />
+        {children}
+        <CaseCTA />
+      </main>
       <Footer />
     </div>
   );

--- a/app/work/northern-trust/page.tsx
+++ b/app/work/northern-trust/page.tsx
@@ -1,5 +1,4 @@
 import { Metadata } from 'next'
-import Link from 'next/link'
 
 export const metadata: Metadata = {
   title: 'Northern Trust Micro-Interactions | Nice Right',
@@ -356,9 +355,6 @@ export default function NorthernTrustPage() {
         </section>
       </div>
 
-      <footer className="v9-case-footer">
-        <Link href="/work" className="v9-case-back"><span aria-hidden="true">← </span>All Work</Link>
-      </footer>
     </article>
   )
 }

--- a/app/work/work.css
+++ b/app/work/work.css
@@ -193,12 +193,12 @@
 
 .v9-case-header h1 {
   font-family: var(--v9-font-heading);
-  font-size: clamp(1.8rem, 3.5vw, 3rem);
+  font-size: clamp(2.25rem, 4.5vw, 3.75rem);
   font-weight: 400;
   color: #fff;
-  line-height: 1.15;
-  letter-spacing: -0.02em;
-  margin: 0 0 20px;
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+  margin: 0 0 24px;
 }
 
 .v9-case-subtitle {
@@ -210,9 +210,10 @@
 
 .v9-case-meta {
   display: flex;
-  gap: 40px;
+  gap: 48px;
   flex-wrap: wrap;
-  padding-top: 32px;
+  padding-top: 40px;
+  margin-top: 8px;
   border-top: 1px solid rgba(255, 255, 255, 0.1);
 }
 
@@ -350,6 +351,113 @@
   margin-top: 12px;
 }
 
+/* ==========================================================================
+   Breadcrumb
+   ========================================================================== */
+
+.v9-breadcrumb {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 88px 24px 0;
+}
+
+.v9-breadcrumb-list {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 0.8rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+.v9-breadcrumb-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: rgba(255, 255, 255, 0.35);
+}
+
+.v9-breadcrumb-item a {
+  color: rgba(255, 255, 255, 0.45);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.v9-breadcrumb-item a:hover {
+  color: var(--v9-accent-light);
+}
+
+.v9-breadcrumb-item span[aria-current='page'] {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.v9-breadcrumb-sep {
+  color: rgba(255, 255, 255, 0.2);
+}
+
+/* ==========================================================================
+   Case study CTA
+   ========================================================================== */
+
+.v9-case-cta {
+  margin-top: 80px;
+  padding: 80px 24px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.v9-case-cta-inner {
+  max-width: 600px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.v9-case-cta-label {
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--v9-accent-light);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0 0 16px;
+}
+
+.v9-case-cta-heading {
+  font-family: var(--v9-font-heading);
+  font-size: clamp(1.75rem, 3.5vw, 2.75rem);
+  font-weight: 400;
+  color: #ffffff;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  margin: 0 0 32px;
+}
+
+.v9-case-cta-btn {
+  display: inline-block;
+  padding: 16px 32px;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #ffffff;
+  background: linear-gradient(135deg, #0b8a6e 0%, #06d6a0 100%);
+  text-decoration: none;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
+  box-shadow: 0 4px 20px rgba(6, 214, 160, 0.25);
+}
+
+.v9-case-cta-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 28px rgba(6, 214, 160, 0.35);
+}
+
+/* ==========================================================================
+   Responsive
+   ========================================================================== */
+
 @media (max-width: 768px) {
   .v9-case {
     padding: 120px 20px 60px;
@@ -357,5 +465,13 @@
 
   .v9-case-meta {
     gap: 24px;
+  }
+
+  .v9-breadcrumb {
+    padding-top: 80px;
+  }
+
+  .v9-case-cta {
+    padding: 60px 20px;
   }
 }

--- a/docs/brand-guidelines.md
+++ b/docs/brand-guidelines.md
@@ -316,6 +316,34 @@ Examples: "Results", "Services", "Testimonials", "FAQ"
 - CTA button right: "Book a Free Call"
 - Scroll progress bar in amber (subtle)
 
+**Nav variants** (`app/_shared/nav.css`):
+
+| Class | Background | Text | When used |
+|---|---|---|---|
+| *(none)* | Transparent | White | Default; hero scroll behaviour |
+| `.v9-nav--solid` | `rgba(255,255,255,0.95)` | Dark `#0c1117` | Homepage after hero exits viewport |
+| `.v9-nav--solid-dark` | `rgba(12,17,23,0.95)` | White / teal accent | Work/case-study pages (`variant="dark"` prop) |
+
+To use the dark variant: `<Nav defaultSolid variant="dark" />` — keeps the nav immediately opaque on page load while applying the dark palette.
+
+### Breadcrumb
+
+Used on all `/work/*` routes, rendered by `app/work/layout.tsx`.
+
+- Component: `app/work/_components/Breadcrumb.tsx`
+- Renders: `Home / Work / [Page Title]`
+- Styles: `.v9-breadcrumb` in `app/work/work.css`
+- Label map is a static const in the component — update it when adding new case studies
+
+### Case Study CTA Card
+
+Persistent section at the bottom of every case study page, inserted by the work layout.
+
+- Component: `app/work/_components/CaseCTA.tsx`
+- Copy: "Let's work together" → `/#contact`
+- Fires: `cta_click` GA4 event with `location: 'case_study_footer'`
+- Styles: `.v9-case-cta` in `app/work/work.css`
+
 ### Hero Section
 
 - Headline with accent color on second line

--- a/docs/interaction-design-analysis.md
+++ b/docs/interaction-design-analysis.md
@@ -192,6 +192,17 @@ Based on visual inspection and GSAP library usage:
 
 ## 4. NAVIGATION INTERACTIONS
 
+### Nav Variant Behaviour
+
+The nav component (`app/_home/components/Nav.tsx`) supports two solid states, determined by layout context:
+
+| Prop | Solid class | Visual |
+|---|---|---|
+| `<Nav />` (default) | None on load; `.v9-nav--solid` after hero scrolls past | Transparent → white |
+| `<Nav defaultSolid variant="dark" />` | `.v9-nav--solid-dark` immediately on mount | Dark `rgba(12,17,23,0.95)` always |
+
+The `defaultSolid` prop skips the GSAP ScrollTrigger entirely and forces `solid=true` on mount. This is used on work/case study pages where there is no `#hero` element to trigger the scroll transition. The `variant="dark"` prop then selects the dark palette so the opaque nav matches the page background.
+
 ### Current State
 
 #### Anchor Link Smooth Scrolling


### PR DESCRIPTION
## Summary

- **Nav bug fixed**: case study pages had white nav on dark `#0C1117` background. Added `.v9-nav--solid-dark` CSS variant + `variant` prop on `Nav`; work layout now passes `variant="dark"`.
- **Breadcrumb**: new `app/work/_components/Breadcrumb.tsx` — `Home / Work / [Page Title]` on all `/work/*` routes.
- **CTA card**: new `app/work/_components/CaseCTA.tsx` — "Let's work together" → `/#contact`, fires `cta_click` GA4 event; replaces the lone `← All Work` back-link footer.
- **Visual hierarchy**: bumped case-study `h1` from `clamp(1.8rem, 3.5vw, 3rem)` to `clamp(2.25rem, 4.5vw, 3.75rem)`, increased meta section spacing.
- **Docs**: `brand-guidelines.md` and `interaction-design-analysis.md` updated with nav variant table, breadcrumb and CTA card entries.

## Test plan

- [ ] Visit `/work/healthcare-real-estate` — nav is dark (not white)
- [ ] Visit `/work/northern-trust` and `/work/green-goods` — same dark nav
- [ ] Breadcrumb shows `Home / Work / [Case Name]` at top of each case study
- [ ] CTA section "Let's work together" renders below content
- [ ] CTA click navigates to `/#contact`
- [ ] Homepage nav behavior unchanged (transparent → white on scroll)
- [ ] Build passes (`npm run build`)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)